### PR TITLE
Activate extra usbhost overlays for neo

### DIFF
--- a/config/boards/nanopineo.conf
+++ b/config/boards/nanopineo.conf
@@ -5,7 +5,7 @@ BOOTCONFIG="nanopi_neo_defconfig"
 #
 MODULES="#w1-sunxi #w1-gpio #w1-therm #sunxi-cir g_serial"
 MODULES_NEXT="g_serial"
-DEFAULT_OVERLAYS="usbhost1 usbhost2"
+DEFAULT_OVERLAYS="usbhost0 usbhost1 usbhost2 usbhost3"
 CPUMIN="240000"
 CPUMAX="912000"
 #


### PR DESCRIPTION
This allows us to remove the corresponding step in our ansible playbook.
The headers only expose 3 USB ports on the pin headers, and that's the
basis by which the default overlays are set upstream, so it makes sense
to keep this in our tree.